### PR TITLE
fix: Disable duplicate deployment triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,28 +1,31 @@
-name: Deploy
+# Deploy workflow disabled - using Render Auto-Deploy instead
+# This prevents duplicate deployments caused by both Auto-Deploy and webhook triggers
 
-on:
-  push:
-    branches: [main]
+# name: Deploy
 
-jobs:
-  deploy-server:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Deploy Server
-        env:
-          DEPLOY_URL: ${{ secrets.RENDER_SERVER_DEPLOY_HOOK_URL }}
-        run: |
-          echo "Triggering server deploy..."
-          curl -X POST "$DEPLOY_URL"
+# on:
+#   push:
+#     branches: [main]
 
-  deploy-client:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Deploy Client
-        env:
-          DEPLOY_URL: ${{ secrets.RENDER_CLIENT_DEPLOY_HOOK_URL }}
-        run: |
-          echo "Triggering client deploy..."
-          curl -X POST "$DEPLOY_URL"
+# jobs:
+#   deploy-server:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Deploy Server
+#         env:
+#           DEPLOY_URL: ${{ secrets.RENDER_SERVER_DEPLOY_HOOK_URL }}
+#         run: |
+#           echo "Triggering server deploy..."
+#           curl -X POST "$DEPLOY_URL"
+
+#   deploy-client:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Deploy Client
+#         env:
+#           DEPLOY_URL: ${{ secrets.RENDER_CLIENT_DEPLOY_HOOK_URL }}
+#         run: |
+#           echo "Triggering client deploy..."
+#           curl -X POST "$DEPLOY_URL"


### PR DESCRIPTION
🔧 Deployment Fix:
- Commented out GitHub Actions deploy webhook triggers
- Prevents duplicate deployments (Auto-Deploy + webhook)
- Resolves 'Deploy canceled' issues from overlapping triggers

✅ Deployment Strategy:
- Use Render Auto-Deploy for automatic deployment on main branch push
- Simpler, more reliable deployment process
- CI/CD testing still runs before merge

This eliminates the duplicate deployment issue where both Auto-Deploy and webhook triggers were starting simultaneous deployments.