### PR TITLE
revert: Restore apolloClient.ts and vite.config.ts to pre-chunking state

### DIFF
--- a/client/src/api/apolloClient.ts
+++ b/client/src/api/apolloClient.ts
@@ -14,9 +14,7 @@ import {
 
 // Create an HTTP link for GraphQL server
 const httpLink = createHttpLink({
-  uri: import.meta.env.VITE_GRAPHQL_ENDPOINT || 
-       import.meta.env.VITE_API_URL || 
-       '/graphql', // Fallback to relative path in production
+  uri: import.meta.env.VITE_GRAPHQL_ENDPOINT || '/graphql',
 });
 
 // Handle authentication via token in localStorage
@@ -74,24 +72,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
 // Create the Apollo Client
 const client = new ApolloClient({
   link: from([errorLink, authLink, httpLink]),
-  cache: new InMemoryCache({
-    // Add cache configuration to prevent potential issues
-    addTypename: true,
-    resultCaching: true,
-  }),
-  // Add default options to prevent common errors
-  defaultOptions: {
-    watchQuery: {
-      errorPolicy: 'all',
-      fetchPolicy: 'cache-and-network',
-    },
-    query: {
-      errorPolicy: 'all',
-      fetchPolicy: 'cache-first',
-    },
-  },
-  // Enable developer tools in non-production
-  connectToDevTools: process.env.NODE_ENV !== 'production',
+  cache: new InMemoryCache(),
 });
 
 export default client;


### PR DESCRIPTION
- Reverted apolloClient.ts to simple InMemoryCache configuration
- Removed defensive error policies and cache settings that may have caused issues
- Reverted vite.config.ts to original React chunking strategy (separate react/router chunks)
- Removed comprehensive React bundling that was causing production errors
- Restored original PWA theme colors (#C9A66B, #FAF6F0)
- Removed Brotli compression and service worker cache conflict fixes
- Reverted build targets back to es2019/safari14
- Removed define and optimizeDeps sections

This restores both files to their working state before commit 1809e09 when chunking changes began.