### PR TITLE
fix: restore missing CSS for timeline and sections after /styles/ cleanup

### DIFF
--- a/client/src/assets/sections.css
+++ b/client/src/assets/sections.css
@@ -1,0 +1,152 @@
+/* =================== Section Layout & Animations =================== */
+
+/* Section Layout */
+section {
+  padding: var(--spacing-16) var(--spacing-4);
+  min-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  scroll-margin-top: 72px;
+  overflow: hidden;
+}
+
+section:nth-child(even) {
+  background-color: var(--color-bg);
+}
+
+section:nth-child(odd) {
+  background-color: #fff;
+}
+
+section:not(:first-child)::before {
+  content: "";
+  position: absolute;
+  top: -50px;
+  left: 0;
+  right: 0;
+  height: 100px;
+  background: inherit;
+  transform: skewY(-1.5deg);
+  transform-origin: 100%;
+  z-index: 1;
+}
+
+.section-title {
+  font-family: "Playfair Display", serif;
+  font-size: var(--font-xl);
+  text-align: center;
+  margin-bottom: var(--spacing-8);
+  position: relative;
+  display: inline-block;
+  z-index: 2;
+  color: var(--color-secondary);
+}
+
+.section-title::after {
+  content: "";
+  position: absolute;
+  width: 80px;
+  height: 3px;
+  background: linear-gradient(
+    to right,
+    var(--color-accent),
+    var(--color-primary)
+  );
+  bottom: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 2px;
+}
+
+.section-content {
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  z-index: 2;
+  position: relative;
+  padding: var(--spacing-4);
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes heroContentFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(30px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes slideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Animation Classes */
+.fade-in {
+  animation: fadeIn 0.8s ease-out forwards;
+}
+
+.slide-in-left {
+  animation: slideInLeft 0.8s ease-out forwards;
+}
+
+.slide-in-right {
+  animation: slideInRight 0.8s ease-out forwards;
+}
+
+.delay-1 {
+  animation-delay: 0.2s;
+}
+
+.delay-2 {
+  animation-delay: 0.4s;
+}
+
+.delay-3 {
+  animation-delay: 0.6s;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  section {
+    padding: var(--spacing-8) var(--spacing-3);
+  }
+
+  .section-title {
+    font-size: var(--font-lg);
+  }
+}

--- a/client/src/assets/styles.css
+++ b/client/src/assets/styles.css
@@ -1,4 +1,5 @@
 /* Import all component-specific styles first */
+@import "./sections.css";
 @import "./mobile-enhancements.css";
 @import "./mobile-drawer.css";
 @import "./FAQ.css";

--- a/client/src/assets/timeline.css
+++ b/client/src/assets/timeline.css
@@ -1,115 +1,72 @@
-/* timeline.css */
+/* Mobile-First Timeline: Simple Vertical Cards */
+/* This matches the classes used in OurStory.tsx component */
 
-/* make the timeline itself the positioning context */
-#our-story .timeline {
-  position: relative;
-  margin: 4rem auto;
-  padding: 0;
-  width: 90%;
-}
-
-/* the vertical “spine” */
-#our-story .timeline::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 4px;
-  background: var(--color-sage);
-  transform: translateX(-50%);
-  z-index: 0;
+.story-timeline {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: var(--spacing-4);
 }
 
-/* each item is half the width, with vertical padding only */
-#our-story .timeline-item {
-  position: relative;
-  width: 50%;
-  padding: 2rem 0;
-  box-sizing: border-box;
-}
-
-/* left-side blocks get a right gutter, right-side blocks get a left gutter */
-#our-story .timeline-item.left {
-  left: 0;
-  padding-right: var(--spacing-6);
-  text-align: right;
-}
-#our-story .timeline-item.right {
-  left: 50%;
-  padding-left: var(--spacing-6);
-  text-align: left;
-}
-
-/* the blue “dot” */
-#our-story .timeline-item::after {
-  content: "";
-  position: absolute;
-  top: 2.5rem;                /* tweak this to vertically center the dot */
-  width: 14px;
-  height: 14px;
-  background: var(--color-dusty-blue);
-  border: 3px solid var(--color-cream);
-  border-radius: 50%;
-  transform: translateX(-50%);
-  z-index: 1;
-}
-/* left-items: dot sits at the right edge of that 50% column */
-#our-story .timeline-item.left::after {
-  left: 100%;
-}
-/* right-items: dot sits at the left edge of that 50% column */
-#our-story .timeline-item.right::after {
-  left: 0;
-}
-
-/* the card inside each item */
-#our-story .timeline-content {
-  position: relative;
-  display: inline-block;
-  max-width: 300px;
+.story-event {
   background: var(--color-panel-cream);
   border-radius: var(--radius);
-  padding: 1rem;
-  box-shadow: var(--shadow-md);
-  z-index: 2;
-}
-#our-story .timeline-content img {
-  width: 100%;
-  border-radius: var(--radius);
-  margin-bottom: 0.75rem;
-  object-fit: cover;
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-/* date + text styling */
-#our-story .timeline-text .timeline-date {
-  display: block;
-  font-size: var(--font-sm);
-  color: var(--color-charcoal);
-  margin-bottom: 0.5rem;
-  font-weight: 600;
+.story-event:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
-#our-story .timeline-text p {
-  margin: 0;
+
+.story-event-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  margin-bottom: var(--spacing-3);
+}
+
+.story-event-date {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-accent);
+  margin-bottom: var(--spacing-2);
+  display: block;
+}
+
+.story-event-text {
   font-size: var(--font-md);
   color: var(--color-charcoal);
+  line-height: 1.5;
+  margin: 0;
 }
 
-/* on narrow viewports, just stack everything */
-@media (max-width: 768px) {
-  #our-story .timeline::before {
-    left: 1rem;
+/* Desktop Enhancement */
+@media (min-width: 768px) {
+  .story-timeline {
+    max-width: 800px;
   }
-  #our-story .timeline-item,
-  #our-story .timeline-item.left,
-  #our-story .timeline-item.right {
-    width: 100%;
-    left: 0 !important;
-    padding: 0 0 2rem 2.5rem;
-    text-align: left;
+
+  .story-event {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-6);
   }
-  #our-story .timeline-item::after {
-    left: 1rem;
-    transform: none;
+
+  .story-event:nth-child(even) {
+    flex-direction: row-reverse;
+  }
+
+  .story-event-image {
+    flex: 0 0 250px;
+    height: 150px;
+    margin-bottom: 0;
+  }
+
+  .story-event-content {
+    flex: 1;
   }
 }


### PR DESCRIPTION
CRITICAL FIXES:
- Add sections.css with layout, animations, and section styling
- Replace timeline.css with mobile-first card design used by OurStory.tsx
- Update styles.css imports to include sections.css

ISSUE RESOLUTION:
- Timeline now uses correct .story-timeline/.story-event classes
- Section layout and animations restored from removed /styles/layout/
- Gallery grid styling preserved in existing assets/styles.css

This fixes the broken timeline display and ensures all components have their required CSS after the /styles/ directory removal.