### PR TITLE
Enable meal selection with finalized dinner menu

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2342,9 +2342,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2401,9 +2401,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3082,9 +3082,9 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3095,9 +3095,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
-      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -3109,9 +3109,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
-      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -3123,9 +3123,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
-      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -3137,9 +3137,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
-      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -3151,9 +3151,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
-      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -3165,9 +3165,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
-      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -3179,13 +3179,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
-      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3193,13 +3196,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
-      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3207,13 +3213,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
-      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,13 +3230,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
-      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,13 +3247,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
-      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3249,13 +3281,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
-      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3263,13 +3315,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
-      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3277,13 +3332,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
-      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,13 +3349,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
-      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3305,13 +3366,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3319,9 +3383,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
-      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -3329,13 +3410,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
-      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -3347,9 +3428,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
-      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -3361,9 +3442,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
-      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -3375,9 +3456,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -3389,9 +3470,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
-      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -3544,16 +3625,6 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@types/aria-query": {
@@ -7193,9 +7264,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7227,9 +7298,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7290,9 +7361,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7308,9 +7379,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7377,9 +7448,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7401,9 +7472,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7472,9 +7543,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7499,9 +7570,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7854,9 +7925,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
       "dev": true,
       "funding": [
         {
@@ -7866,7 +7937,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7963,9 +8034,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7976,13 +8047,13 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8075,9 +8146,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8443,9 +8514,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8454,9 +8525,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10467,9 +10538,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -11617,9 +11688,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12448,9 +12519,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
-      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12464,28 +12535,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.4",
-        "@rollup/rollup-android-arm64": "4.52.4",
-        "@rollup/rollup-darwin-arm64": "4.52.4",
-        "@rollup/rollup-darwin-x64": "4.52.4",
-        "@rollup/rollup-freebsd-arm64": "4.52.4",
-        "@rollup/rollup-freebsd-x64": "4.52.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
-        "@rollup/rollup-linux-arm64-musl": "4.52.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-musl": "4.52.4",
-        "@rollup/rollup-openharmony-arm64": "4.52.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
-        "@rollup/rollup-win32-x64-gnu": "4.52.4",
-        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -12536,9 +12610,9 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12700,6 +12774,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -13591,18 +13675,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -13758,9 +13842,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13769,9 +13853,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13855,9 +13939,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14929,9 +15013,9 @@
       }
     },
     "node_modules/vite-node/node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
+      "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -15636,9 +15720,9 @@
       }
     },
     "node_modules/vitest/node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
+      "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -16085,26 +16169,26 @@
       }
     },
     "node_modules/workbox-build/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/workbox-build/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/workbox-build/node_modules/estree-walker": {
@@ -16190,13 +16274,13 @@
       }
     },
     "node_modules/workbox-build/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -16219,9 +16303,9 @@
       }
     },
     "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/client/src/assets/rsvp-enhancements.css
+++ b/client/src/assets/rsvp-enhancements.css
@@ -623,6 +623,7 @@
   background-position: right var(--spacing-3) center;
   background-size: 16px;
   padding-right: calc(var(--spacing-4) + 24px); /* Space for arrow */
+  min-height: 56px; /* 12+12 padding + 4 border + 28 line-height = 56 */
 }
 
 .form-input:focus,

--- a/client/src/components/RSVP/MealPreferencesComingSoon.tsx
+++ b/client/src/components/RSVP/MealPreferencesComingSoon.tsx
@@ -1,10 +1,11 @@
 import './MealPreferencesComingSoon.css';
 
 /**
- * MealPreferencesComingSoon - Placeholder banner for meal selection feature
+ * MealPreferencesComingSoon - Dinner menu summary banner
  *
- * Displays when meal preferences feature is disabled (before menu is finalized).
- * Provides clear communication about when meal selection will be available.
+ * Displays when meal preferences feature is disabled in the current environment.
+ * Shows the finalized dinner menu so guests know what to expect even when
+ * meal selection is not yet enabled.
  */
 export default function MealPreferencesComingSoon() {
   return (
@@ -12,37 +13,50 @@ export default function MealPreferencesComingSoon() {
       <div className="coming-soon-icon" aria-hidden="true">
         🍽️
       </div>
-      <h3 className="coming-soon-title">Menu Selection Coming Soon</h3>
+      <h3 className="coming-soon-title">Dinner Menu</h3>
       <p className="coming-soon-description">
-        We're finalizing our delicious menu options and will notify you when
-        meal selection becomes available. You'll be able to choose your
-        preferences before the big day!
+        Our dinner menu is finalized! When meal selection opens, each guest will
+        choose one entree.
       </p>
       <div className="coming-soon-features">
         <div className="feature-item">
           <span className="feature-icon" aria-hidden="true">
-            ✉️
-          </span>
-          <span className="feature-text">Email notification when ready</span>
-        </div>
-        <div className="feature-item">
-          <span className="feature-icon" aria-hidden="true">
-            🌱
+            🥩
           </span>
           <span className="feature-text">
-            Vegetarian, vegan, and dietary options
+            BBQ Beef Brisket with chipotle honey BBQ sauce
           </span>
         </div>
         <div className="feature-item">
           <span className="feature-icon" aria-hidden="true">
-            👶
+            🥩
           </span>
-          <span className="feature-text">Kids menu available</span>
+          <span className="feature-text">
+            Carved Tri Tip with chimichurri, horseradish cream, or au jus
+          </span>
+        </div>
+        <div className="feature-item">
+          <span className="feature-icon" aria-hidden="true">
+            🧒
+          </span>
+          <span className="feature-text">
+            Kids Menu (ages 3-12): Chicken Tenders or Macaroni and Cheese with
+            fries, fruit, and a juice box
+          </span>
+        </div>
+        <div className="feature-item">
+          <span className="feature-icon" aria-hidden="true">
+            🥗
+          </span>
+          <span className="feature-text">
+            Shared for everyone: Field of Greens, Roasted Garlic Mashed
+            Potatoes, and Glazed Carrots
+          </span>
         </div>
       </div>
       <p className="coming-soon-note">
-        <strong>Note:</strong> Please include any food allergies or dietary
-        restrictions in the fields below so we can accommodate your needs.
+        <strong>Note:</strong> Dietary accommodations will be available. Please
+        include any food allergies or dietary restrictions in the fields below.
       </p>
     </div>
   );

--- a/client/src/components/RSVP/MealPreferencesComingSoon.tsx
+++ b/client/src/components/RSVP/MealPreferencesComingSoon.tsx
@@ -15,8 +15,7 @@ export default function MealPreferencesComingSoon() {
       </div>
       <h3 className="coming-soon-title">Dinner Menu</h3>
       <p className="coming-soon-description">
-        Our dinner menu is finalized! When meal selection opens, each guest will
-        choose one entree.
+        Choose your entrée from our finalized menu.
       </p>
       <div className="coming-soon-features">
         <div className="feature-item">
@@ -24,7 +23,7 @@ export default function MealPreferencesComingSoon() {
             🥩
           </span>
           <span className="feature-text">
-            BBQ Beef Brisket with chipotle honey BBQ sauce
+            BBQ Beef Brisket: served with chipotle honey BBQ sauce
           </span>
         </div>
         <div className="feature-item">
@@ -32,7 +31,9 @@ export default function MealPreferencesComingSoon() {
             🥩
           </span>
           <span className="feature-text">
-            Carved Tri Tip with chimichurri, horseradish cream, or au jus
+            Carved Tri Tip: marinated in fresh garlic and herbs, with a
+            peppercorn crust, served with chimichurri, horseradish cream, or au
+            jus
           </span>
         </div>
         <div className="feature-item">
@@ -44,19 +45,10 @@ export default function MealPreferencesComingSoon() {
             fries, fruit, and a juice box
           </span>
         </div>
-        <div className="feature-item">
-          <span className="feature-icon" aria-hidden="true">
-            🥗
-          </span>
-          <span className="feature-text">
-            Every meal includes a Field of Greens salad, Roasted Garlic
-            Mashed Potatoes, and Glazed Carrots
-          </span>
-        </div>
       </div>
       <p className="coming-soon-note">
-        <strong>Note:</strong> Dietary accommodations will be available. Please
-        include any food allergies or dietary restrictions in the fields below.
+        Dietary accommodations are available. Share any allergies or dietary
+        restrictions below.
       </p>
     </div>
   );

--- a/client/src/components/RSVP/MealPreferencesComingSoon.tsx
+++ b/client/src/components/RSVP/MealPreferencesComingSoon.tsx
@@ -49,8 +49,8 @@ export default function MealPreferencesComingSoon() {
             🥗
           </span>
           <span className="feature-text">
-            Shared for everyone: Field of Greens, Roasted Garlic Mashed
-            Potatoes, and Glazed Carrots
+            Every meal includes a Field of Greens salad, Roasted Garlic
+            Mashed Potatoes, and Glazed Carrots
           </span>
         </div>
       </div>

--- a/client/src/components/RSVP/RSVPForm.tsx
+++ b/client/src/components/RSVP/RSVPForm.tsx
@@ -889,11 +889,10 @@ export default function RSVPForm() {
                     </div>
                   )}
                   <p className="form-hint meal-selection-note">
-                    Shared for all guests: Field of Greens salad, Roasted Garlic
-                    Mashed Potatoes, and Glazed Carrots.
-                    {(guest.mealPreference === 'kids_chicken' ||
-                      guest.mealPreference === 'kids_mac') &&
-                      ' Kids meals served with french fries, fresh fruit, and a juice box.'}
+                    {guest.mealPreference === 'kids_chicken' ||
+                    guest.mealPreference === 'kids_mac'
+                      ? 'Kids meals come with french fries, fresh fruit, and a juice box.'
+                      : 'Every meal includes a Field of Greens salad, Roasted Garlic Mashed Potatoes, and Glazed Carrots.'}
                   </p>
                   {guest.mealPreference === 'dietary' && (
                     <p className="form-hint dietary-hint">
@@ -928,8 +927,7 @@ export default function RSVPForm() {
                   id={`guest-${index}-allergies-hint`}
                   className="form-hint"
                 >
-                  Help us ensure this guest has a safe and enjoyable dining
-                  experience
+                  Let us know so we can make sure you're taken care of
                 </small>
               </div>
             </div>

--- a/client/src/components/RSVP/RSVPForm.tsx
+++ b/client/src/components/RSVP/RSVPForm.tsx
@@ -100,7 +100,13 @@ export default function RSVPForm() {
     const normalizedValue = value.toLowerCase().trim();
 
     // Pass through current values; legacy values map to empty (re-selection required)
-    const validValues = ['brisket', 'tritip', 'kids_chicken', 'kids_mac', 'dietary'];
+    const validValues = [
+      'brisket',
+      'tritip',
+      'kids_chicken',
+      'kids_mac',
+      'dietary',
+    ];
     return validValues.includes(normalizedValue) ? normalizedValue : '';
   };
 
@@ -219,9 +225,7 @@ export default function RSVPForm() {
       { value: 'kids_chicken', label: 'Chicken Tenders' },
       { value: 'kids_mac', label: 'Macaroni and Cheese' },
     ],
-    other: [
-      { value: 'dietary', label: 'Dietary Accommodation' },
-    ],
+    other: [{ value: 'dietary', label: 'Dietary Accommodation' }],
   };
 
   // Helper function to update guest count and manage guests array
@@ -889,10 +893,34 @@ export default function RSVPForm() {
                     </div>
                   )}
                   <p className="form-hint meal-selection-note">
-                    {guest.mealPreference === 'kids_chicken' ||
-                    guest.mealPreference === 'kids_mac'
-                      ? 'Kids meals come with french fries, fresh fruit, and a juice box.'
-                      : 'Every meal includes a Field of Greens salad, Roasted Garlic Mashed Potatoes, and Glazed Carrots.'}
+                    {guest.mealPreference === 'brisket' ? (
+                      <>
+                        Served with chipotle honey BBQ sauce.
+                        <br /><br />
+                        Every meal includes a Field of Greens salad, Roasted
+                        Garlic Mashed Potatoes, and Glazed Carrots.
+                      </>
+                    ) : guest.mealPreference === 'tritip' ? (
+                      <>
+                        Marinated in fresh garlic and herbs, with a peppercorn
+                        crust, served with chimichurri, horseradish cream, or au
+                        jus.
+                        <br /><br />
+                        Every meal includes a Field of Greens salad, Roasted
+                        Garlic Mashed Potatoes, and Glazed Carrots.
+                      </>
+                    ) : guest.mealPreference === 'kids_chicken' ||
+                      guest.mealPreference === 'kids_mac' ? (
+                      <>
+                        Kids meals come with french fries, fresh fruit, and a
+                        juice box.
+                      </>
+                    ) : (
+                      <>
+                        Every meal includes a Field of Greens salad, Roasted
+                        Garlic Mashed Potatoes, and Glazed Carrots.
+                      </>
+                    )}
                   </p>
                   {guest.mealPreference === 'dietary' && (
                     <p className="form-hint dietary-hint">

--- a/client/src/components/RSVP/RSVPForm.tsx
+++ b/client/src/components/RSVP/RSVPForm.tsx
@@ -99,20 +99,9 @@ export default function RSVPForm() {
 
     const normalizedValue = value.toLowerCase().trim();
 
-    // Map legacy values to current form values
-    const legacyMapping: Record<string, string> = {
-      vegetarian: 'vegetarian',
-      chicken: 'chicken',
-      beef: 'beef',
-      fish: 'fish',
-      salmon: 'fish',
-      vegan: 'vegan',
-      kids: 'kids',
-      kid: 'kids',
-      children: 'kids',
-    };
-
-    return legacyMapping[normalizedValue] || '';
+    // Pass through current values; legacy values map to empty (re-selection required)
+    const validValues = ['brisket', 'tritip', 'kids_chicken', 'kids_mac', 'dietary'];
+    return validValues.includes(normalizedValue) ? normalizedValue : '';
   };
 
   const [formData, setFormData] = useState<RSVPFormData>(() => {
@@ -219,16 +208,21 @@ export default function RSVPForm() {
     }
   }, [rsvp]); // Only depend on rsvp data, not successMessage
 
-  // Available meal options
-  const mealOptions = [
-    { value: '', label: 'Select your preference' },
-    { value: 'chicken', label: '🍗 Herb-Roasted Chicken' },
-    { value: 'beef', label: '🥩 Grilled Beef Tenderloin' },
-    { value: 'fish', label: '🐟 Pan-Seared Salmon' },
-    { value: 'vegetarian', label: '🥗 Vegetarian Pasta Primavera' },
-    { value: 'vegan', label: '🌱 Vegan Mediterranean Bowl' },
-    { value: 'kids', label: '🍕 Kids Menu (Chicken Tenders & Fries)' },
-  ];
+  // Available meal options — grouped by adult entrees, kids menu, and dietary accommodation
+  const mealOptions = {
+    placeholder: { value: '', label: 'Select your entree' },
+    adult: [
+      { value: 'brisket', label: 'BBQ Beef Brisket' },
+      { value: 'tritip', label: 'Carved Tri Tip' },
+    ],
+    kids: [
+      { value: 'kids_chicken', label: 'Chicken Tenders' },
+      { value: 'kids_mac', label: 'Macaroni and Cheese' },
+    ],
+    other: [
+      { value: 'dietary', label: 'Dietary Accommodation' },
+    ],
+  };
 
   // Helper function to update guest count and manage guests array
   const updateGuestCount = (newCount: number) => {
@@ -852,7 +846,24 @@ export default function RSVPForm() {
                           : 'false'
                       }
                     >
-                      {mealOptions.map(option => (
+                      <option value={mealOptions.placeholder.value}>
+                        {mealOptions.placeholder.label}
+                      </option>
+                      <optgroup label="Adult Entrees">
+                        {mealOptions.adult.map(option => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </optgroup>
+                      <optgroup label="Kids Menu (ages 3-12)">
+                        {mealOptions.kids.map(option => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </optgroup>
+                      {mealOptions.other.map(option => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
@@ -876,6 +887,19 @@ export default function RSVPForm() {
                       </span>
                       {validationErrors[`guest-${index}-mealPreference`]}
                     </div>
+                  )}
+                  <p className="form-hint meal-selection-note">
+                    Shared for all guests: Field of Greens salad, Roasted Garlic
+                    Mashed Potatoes, and Glazed Carrots.
+                    {(guest.mealPreference === 'kids_chicken' ||
+                      guest.mealPreference === 'kids_mac') &&
+                      ' Kids meals served with french fries, fresh fruit, and a juice box.'}
+                  </p>
+                  {guest.mealPreference === 'dietary' && (
+                    <p className="form-hint dietary-hint">
+                      Please describe your dietary needs in the field below so
+                      our kitchen can prepare a suitable meal for you.
+                    </p>
                   )}
                 </div>
               )}

--- a/client/src/components/admin/AdminRSVPManager.tsx
+++ b/client/src/components/admin/AdminRSVPManager.tsx
@@ -48,6 +48,19 @@ interface AdminRSVPManagerProps {
   onUpdate: () => void;
 }
 
+const MEAL_PREFERENCE_LABELS: Record<string, string> = {
+  brisket: 'BBQ Beef Brisket',
+  tritip: 'Carved Tri Tip',
+  kids_chicken: 'Kids - Chicken Tenders',
+  kids_mac: 'Kids - Macaroni and Cheese',
+  dietary: 'Dietary Accommodation',
+};
+
+const formatMealPreferenceLabel = (mealPreference: string): string => {
+  const normalized = mealPreference.trim().toLowerCase();
+  return MEAL_PREFERENCE_LABELS[normalized] || mealPreference;
+};
+
 /**
  * Admin RSVP Manager - Guest management interface for administrators.
  * Allows viewing, editing, and managing all guest RSVPs and user information.
@@ -562,7 +575,9 @@ const AdminRSVPManager: React.FC<AdminRSVPManagerProps> = ({
                       >
                         <span className="guest-name">{g.fullName}</span>
                         {g.mealPreference && (
-                          <span className="meal-badge">{g.mealPreference}</span>
+                          <span className="meal-badge">
+                            {formatMealPreferenceLabel(g.mealPreference)}
+                          </span>
                         )}
                         {g.allergies && (
                           <span className="allergy-badge">
@@ -664,9 +679,7 @@ const AdminRSVPManager: React.FC<AdminRSVPManagerProps> = ({
                           </div>
 
                           <div className="form-row">
-                            <input
-                              type="text"
-                              placeholder="Meal Preference (e.g., Chicken, Vegetarian, Fish)"
+                            <select
                               value={guest.mealPreference}
                               onChange={e =>
                                 handleGuestChange(
@@ -676,7 +689,18 @@ const AdminRSVPManager: React.FC<AdminRSVPManagerProps> = ({
                                 )
                               }
                               className="form-input"
-                            />
+                            >
+                              <option value="">Not specified</option>
+                              <optgroup label="Adult Entrees">
+                                <option value="brisket">BBQ Beef Brisket</option>
+                                <option value="tritip">Carved Tri Tip</option>
+                              </optgroup>
+                              <optgroup label="Kids Menu (ages 3-12)">
+                                <option value="kids_chicken">Chicken Tenders</option>
+                                <option value="kids_mac">Macaroni and Cheese</option>
+                              </optgroup>
+                              <option value="dietary">Dietary Accommodation</option>
+                            </select>
                           </div>
 
                           <div className="form-row">

--- a/client/tests/AdminDashboard.e2e.test.tsx
+++ b/client/tests/AdminDashboard.e2e.test.tsx
@@ -37,8 +37,8 @@ const mockStats = {
     totalMaybe: 0,
     rsvpPercentage: 50,
     mealPreferences: [
-      { preference: 'Chicken', count: 20 },
-      { preference: 'Beef', count: 20 },
+      { preference: 'BBQ Beef Brisket', count: 20 },
+      { preference: 'Carved Tri Tip', count: 20 },
     ],
     dietaryRestrictions: ['Gluten Free', 'Vegan'],
   },
@@ -72,7 +72,7 @@ const mockRSVPs = {
         guests: [
           {
             fullName: 'Guest One',
-            mealPreference: 'Chicken',
+            mealPreference: 'brisket',
             dietaryRestrictions: 'None',
             ageGroup: 'Adult',
             allergies: 'None',

--- a/client/tests/Navbar.e2e.test.tsx
+++ b/client/tests/Navbar.e2e.test.tsx
@@ -1,10 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import Navbar from "../src/components/Navbar";
-import { AuthProvider } from "../src/context/AuthContext";
-import { MemoryRouter } from "react-router-dom";
-import { MockedProvider } from "@apollo/client/testing";
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import Navbar from '../src/components/Navbar';
+import { AuthProvider } from '../src/context/AuthContext';
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
 import '@testing-library/jest-dom';
 
 function renderNavbar() {
@@ -19,37 +18,37 @@ function renderNavbar() {
   );
 }
 
-describe("Navbar integration", () => {
-  it("shows login button when logged out", async () => {
+describe('Navbar integration', () => {
+  it('shows login button when logged out', async () => {
     renderNavbar();
-    const loginButton = screen.getByRole("button", { name: /login/i });
+    const loginButton = screen.getByRole('button', { name: /login/i });
     expect(loginButton).toBeInTheDocument();
 
     // Check that the button has the correct title attribute
     expect(loginButton).toHaveAttribute(
-      "title",
-      "Scan your invitation QR code to access your account"
+      'title',
+      'Scan your invitation QR code to access your account'
     );
 
     // Check for the mobile icon
-    expect(screen.getByText("📱")).toBeInTheDocument();
+    expect(screen.getByText('📱')).toBeInTheDocument();
   });
 
-  it("shows Logout button when logged in", async () => {
+  it('shows Logout button when logged in', async () => {
     // Simulate login by setting localStorage
-    window.localStorage.setItem("id_token", "mock");
+    window.localStorage.setItem('id_token', 'mock');
     window.localStorage.setItem(
-      "user",
+      'user',
       JSON.stringify({
         isInvited: true,
-        fullName: "Test",
-        email: "test@example.com",
+        fullName: 'Test',
+        email: 'test@example.com',
       })
     );
     renderNavbar();
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /logout/i })
+        screen.getByRole('button', { name: /logout/i })
       ).toBeInTheDocument();
     });
     // Clean up

--- a/client/tests/PersonalizedWelcome.e2e.test.tsx
+++ b/client/tests/PersonalizedWelcome.e2e.test.tsx
@@ -281,9 +281,7 @@ describe('PersonalizedWelcome - Banner System', () => {
       const banner = screen.getByTestId('personalized-welcome-banner');
       // Should show RSVP reminder instead
       expect(banner).toHaveAttribute('data-banner-type', 'rsvp-reminder');
-      expect(banner).toHaveTextContent(
-        /Please RSVP when you have a moment/i
-      );
+      expect(banner).toHaveTextContent(/Please RSVP when you have a moment/i);
     });
   });
 
@@ -397,6 +395,7 @@ describe('PersonalizedWelcome - Banner System', () => {
         isAdmin: false,
         hasRSVPed: true,
         rsvp: {
+          _id: 'rsvp-user-14',
           attending: 'YES',
         },
       };

--- a/client/tests/QRLoginModal.e2e.test.tsx
+++ b/client/tests/QRLoginModal.e2e.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import QRLoginModal from '../src/components/QRLoginModal';
 import { AuthProvider } from '../src/context/AuthContext';
 import { MockedProvider } from '@apollo/client/testing';

--- a/client/tests/RSVPForm.e2e.test.tsx
+++ b/client/tests/RSVPForm.e2e.test.tsx
@@ -51,14 +51,14 @@ const createdAttendingRSVP = {
   guests: [
     {
       fullName: 'Test User',
-      mealPreference: 'vegetarian',
+      mealPreference: 'brisket',
       allergies: '',
     },
   ],
   additionalNotes: '',
   // Legacy fields for backward compatibility
   fullName: 'Test User',
-  mealPreference: 'vegetarian',
+  mealPreference: 'brisket',
   allergies: '',
 };
 
@@ -106,14 +106,14 @@ const createAttendingRSVPMock = {
         guests: [
           {
             fullName: 'Test User',
-            mealPreference: 'vegetarian',
+            mealPreference: 'brisket',
             allergies: '',
           },
         ],
         additionalNotes: '',
         // Legacy fields synchronized with first guest for backward compatibility
         fullName: 'Test User',
-        mealPreference: 'vegetarian',
+        mealPreference: 'brisket',
         allergies: '',
       },
     },
@@ -237,12 +237,12 @@ describe('RSVPForm integration', () => {
       ) as HTMLSelectElement;
 
       // Complete form filling - userEvent handles async, no act() needed
-      await user.selectOptions(mealPrefSelect, 'vegetarian');
+      await user.selectOptions(mealPrefSelect, 'brisket');
 
       // Verify form state
       expect(fullNameInput.value).toBe('Test User');
       expect(attendingYesRadio.checked).toBe(true);
-      expect(mealPrefSelect.value).toBe('vegetarian');
+      expect(mealPrefSelect.value).toBe('brisket');
 
       // Submit the form
       await user.click(screen.getByRole('button', { name: /submit rsvp/i }));
@@ -666,7 +666,7 @@ describe('RSVPForm integration', () => {
       // Coming soon banner should be visible
       await waitFor(() => {
         expect(
-          screen.getByText(/menu selection coming soon/i)
+          screen.getByText(/dinner menu/i)
         ).toBeInTheDocument();
       });
 

--- a/client/tests/RSVPForm.e2e.test.tsx
+++ b/client/tests/RSVPForm.e2e.test.tsx
@@ -10,11 +10,9 @@ import { CREATE_RSVP } from '../src/features/rsvp/graphql/mutations';
 
 // Mock feature flags - enable meal preferences for these tests
 // (tests were written with meal preferences visible)
-vi.mock('../src/config/features', () => ({
-  features: {
-    mealPreferencesEnabled: true,
-  },
-}));
+vi.mock('../src/config/features', async () => {
+  return { features: { mealPreferencesEnabled: true } };
+});
 
 /**
  * RSVPForm E2E Test Suite
@@ -641,15 +639,39 @@ describe('RSVPForm integration', () => {
 
   describe('Meal Preferences Feature Flag (disabled)', () => {
     it('hides meal preference fields and shows coming soon banner when feature is disabled', async () => {
-      // Override the mock for this test to disable meal preferences
-      const { features } = await import('../src/config/features');
-      const originalValue = features.mealPreferencesEnabled;
-      features.mealPreferencesEnabled = false;
+      // Clean up any prior renders and reset module cache
+      const { cleanup } = await import('@testing-library/react');
+      cleanup();
+
+      vi.resetModules();
+      vi.doMock('../src/config/features', () => ({
+        features: { mealPreferencesEnabled: false },
+      }));
+
+      // Dynamic imports to pick up the new mock (resetModules cleared cache)
+      const { default: RSVPFormDisabled } = await import(
+        '../src/components/RSVP/RSVPForm'
+      );
+      const { MockedProvider: MP } = await import('@apollo/client/testing');
+      const { AuthProvider: AP } = await import('../src/context/AuthContext');
+      const { GET_RSVP: GR } = await import(
+        '../src/features/rsvp/graphql/queries'
+      );
+      const freshMock = () => ({
+        request: { query: GR },
+        result: { data: { getRSVP: null } },
+      });
 
       const user = userEvent.setup();
 
       await act(async () => {
-        renderRSVPForm();
+        render(
+          <MP mocks={[freshMock(), freshMock()]} addTypename={false}>
+            <AP>
+              <RSVPFormDisabled />
+            </AP>
+          </MP>
+        );
       });
 
       const attendingYesRadio = screen.getByDisplayValue(
@@ -666,12 +688,14 @@ describe('RSVPForm integration', () => {
       // Coming soon banner should be visible
       await waitFor(() => {
         expect(
-          screen.getByText(/dinner menu/i)
+          screen.getByRole('heading', { name: /dinner menu/i })
         ).toBeInTheDocument();
       });
 
-      // Restore original value
-      features.mealPreferencesEnabled = originalValue;
+      // Restore original mock for any subsequent tests
+      vi.doMock('../src/config/features', () => ({
+        features: { mealPreferencesEnabled: true },
+      }));
     });
   });
 });

--- a/client/tests/tsconfig.json
+++ b/client/tests/tsconfig.json
@@ -1,8 +1,16 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"],
     "jsx": "react-jsx"
   },
-  "include": ["./**/*", "./vitest-dom.d.ts"]
+  "include": [
+    "./**/*",
+    "./vitest-dom.d.ts",
+    "../src/vite-env.d.ts",
+    "../src/images.d.ts",
+    "../src/react-app-env.d.ts"
+  ]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -31,6 +31,7 @@
     /* Output */
     "skipLibCheck": true,
     "outDir": "dist",
+    "rootDir": "src",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -52,11 +52,11 @@ See [docs/CONFIGURATION.md](CONFIGURATION.md) for the full env var reference and
 
 ### Meal Preferences (gated — `VITE_ENABLE_MEAL_PREFERENCES`)
 
-- **Status**: Full RSVP form integration complete, gated behind feature flag
+- **Status**: Full RSVP form integration complete; finalized dinner menu with kids menu and dietary accommodation option, gated behind feature flag
 - **Remaining**:
-  - [ ] Finalize wedding menu options
-  - [ ] Update meal enum values in schema if menu differs from current options
   - [ ] Flip `VITE_ENABLE_MEAL_PREFERENCES=true`
+  - [ ] Flip `ENABLE_MEAL_PREFERENCES=true`
+  - [ ] Send RSVP update notice if enabling after guests have already submitted responses
 
 ---
 

--- a/docs/features/MEAL_PREFERENCES_FEATURE_FLAG.md
+++ b/docs/features/MEAL_PREFERENCES_FEATURE_FLAG.md
@@ -2,13 +2,40 @@
 
 ## Overview
 
-Implemented a feature flag system to control when meal selection is available in the RSVP form. This allows you to disable meal preferences until the menu is finalized in April, then re-enable it without code changes.
+Feature flag system controlling when meal selection is available in the RSVP form. The dinner menu is finalized and the RSVP form can be toggled on or off without code changes.
 
 ## Current State
 
-**Feature Status:** ✅ Implemented and tested  
-**Default State:** **DISABLED** (meal preferences hidden from guests)  
+**Feature Status:** ✅ Implemented and tested
+**Default State:** **DISABLED** (meal preferences hidden from guests)
+**Menu Status:** Finalized — 2 adult entrees, kids menu, dietary accommodation option
 **Production Ready:** Yes
+
+## Menu Options
+
+### Adult Entrees (choose one)
+| Stored value | Display label |
+|---|---|
+| `brisket` | BBQ Beef Brisket (with chipotle honey BBQ sauce) |
+| `tritip` | Carved Tri Tip (with chimichurri, horseradish cream, or au jus) |
+
+### Kids Menu (ages 3-12, choose one)
+| Stored value | Display label |
+|---|---|
+| `kids_chicken` | Chicken Tenders |
+| `kids_mac` | Macaroni and Cheese |
+
+Kids meals served with french fries, fresh fruit, and a juice box.
+
+### Dietary Accommodation
+| Stored value | Display label |
+|---|---|
+| `dietary` | Dietary Accommodation |
+
+For guests who cannot eat either adult entree (Celiac, vegan, severe allergies). Prompts the guest to describe their needs in the existing allergies/dietary restrictions field.
+
+### Shared for Everyone
+Field of Greens salad, Roasted Garlic Mashed Potatoes, and Glazed Carrots. These are informational — not selectable options.
 
 ## How to Enable/Disable
 
@@ -18,7 +45,7 @@ Implemented a feature flag system to control when meal selection is available in
 # Disable meal preferences (default - current state)
 ENABLE_MEAL_PREFERENCES=false
 
-# Enable meal preferences (after menu is finalized)
+# Enable meal preferences
 ENABLE_MEAL_PREFERENCES=true
 ```
 
@@ -28,7 +55,7 @@ ENABLE_MEAL_PREFERENCES=true
 # Disable meal preferences (default - current state)
 VITE_ENABLE_MEAL_PREFERENCES=false
 
-# Enable meal preferences (after menu is finalized)
+# Enable meal preferences
 VITE_ENABLE_MEAL_PREFERENCES=true
 ```
 
@@ -38,31 +65,28 @@ VITE_ENABLE_MEAL_PREFERENCES=true
 
 **RSVP Form:**
 
-- Guests see an attractive "Coming Soon" banner instead of meal dropdowns
-- Banner message: "Menu Selection Coming in April"
-- Lists feature preview: email notification, dietary options, kids menu
+- Guests see a "Dinner Menu" summary banner instead of meal dropdowns
+- Banner lists both adult entrees, kids menu, shared sides, and dietary accommodation note
 - Guests can still enter food allergies and dietary restrictions
 - RSVP submission works without meal preferences
 
-**Validation:**
-
-- No meal preference required for attending guests
-- RSVPs succeed without meal selections
-- Allergies/dietary restrictions still collected
-
 **Admin Dashboard:**
 
-- Meal statistics section would show "Menu not yet finalized"
-- Existing RSVPs with meal preferences still display correctly
+- Meal statistics show finalized entree labels for reporting
+- Existing RSVPs with meal preferences display with mapped labels
 
-### When Feature is ENABLED (After April)
+### When Feature is ENABLED
 
 **RSVP Form:**
 
-- Full meal selection dropdown appears for each guest
+- Grouped dropdown appears for each guest with `<optgroup>` sections:
+  - Adult Entrees: BBQ Beef Brisket, Carved Tri Tip
+  - Kids Menu (ages 3-12): Chicken Tenders, Macaroni and Cheese
+  - Dietary Accommodation
 - Required field for attending guests
-- Options: Chicken, Beef, Fish, Vegetarian, Vegan, Kids Menu
-- Real-time validation
+- Shared items displayed as informational text below the dropdown
+- Selecting "Dietary Accommodation" shows a hint to describe needs in the allergies field
+- Selecting a kids option shows kids meal sides info
 
 **Validation:**
 
@@ -71,85 +95,32 @@ VITE_ENABLE_MEAL_PREFERENCES=true
 
 **Admin Dashboard:**
 
-- Full meal preference statistics
+- Full meal preference statistics by finalized entree label
 - Counts by meal type for catering planning
+- Admin edit uses a structured dropdown (not free-text input)
 
 ## Files Modified
 
 ### Backend
 
-- `server/src/config/index.ts` - Added features.mealPreferencesEnabled config
-- `server/src/utils/validation.ts` - Made validateMealPreference accept feature flag parameter
-- `server/src/services/rsvpService.ts` - Pass feature flag to all validation calls
-- `server/src/graphql/typeDefs.ts` - Made mealPreference optional in GraphQL schema
-- `server/src/models/RSVP.ts` - Made mealPreference field not required at model level
-- `server/src/types/graphql.ts` - Added qrAlias to AdminUserUpdateInput (from previous work)
-- `server/tests/rsvp.e2e.test.ts` - Updated tests to handle both feature states
+- `server/src/config/index.ts` - features.mealPreferencesEnabled config
+- `server/src/models/RSVP.ts` - Enum values: brisket, tritip, kids_chicken, kids_mac, dietary
+- `server/src/utils/validation.ts` - validPreferences updated to match enum
+- `server/src/services/rsvpService.ts` - Passes feature flag to validation
+- `server/src/services/adminService.ts` - MEAL_PREFERENCE_LABELS mapping for stats and CSV export
 
 ### Frontend
 
-- `client/src/config/features.ts` - **NEW** - Feature flag configuration
-- `client/src/components/RSVP/RSVPForm.tsx` - Conditional rendering based on feature flag
-- `client/src/components/RSVP/MealPreferencesComingSoon.tsx` - **NEW** - Coming soon banner
-- `client/src/components/RSVP/MealPreferencesComingSoon.css` - **NEW** - Banner styles
-
-### Configuration
-
-- `server/.env.example` - Added ENABLE_MEAL_PREFERENCES documentation
-- `client/.env.example` - Added VITE_ENABLE_MEAL_PREFERENCES documentation
-
-## Testing Results
-
-### Backend Tests (server/tests/rsvp.e2e.test.ts)
-
-✅ **With Feature DISABLED:** 9/9 tests passing
-
-- RSVPs succeed without meal preferences
-- Validation skips meal requirement
-- All other validations work normally
-
-✅ **With Feature ENABLED:** 9/9 tests passing
-
-- Meal preferences required for attending guests
-- Validation errors thrown when missing
-- Standard behavior maintained
-
-### Build Verification
-
-✅ **Backend Build:** TypeScript compilation successful  
-✅ **Frontend Build:** Vite production build successful
+- `client/src/config/features.ts` - Feature flag configuration
+- `client/src/components/RSVP/RSVPForm.tsx` - Grouped meal dropdown, shared items note, dietary hint
+- `client/src/components/RSVP/MealPreferencesComingSoon.tsx` - Dinner menu summary banner
+- `client/src/components/admin/AdminRSVPManager.tsx` - Label mapping and structured dropdown
 
 ## Deployment Instructions
 
-### For Current State (Meal Preferences DISABLED)
+### To Enable Meal Preferences
 
-**No action required** - feature is disabled by default in both environments.
-
-1. Verify `.env` files exist:
-
-   ```bash
-   # Server: server/.env
-   ENABLE_MEAL_PREFERENCES=false
-
-   # Client: client/.env
-   VITE_ENABLE_MEAL_PREFERENCES=false
-   ```
-
-2. Deploy normally:
-
-   ```bash
-   # Backend
-   cd server && npm install && npm run build
-
-   # Frontend
-   cd client && npm install && npm run build
-   ```
-
-3. Guests will see "Coming Soon" banner when RSVPing
-
-### To Enable Meal Preferences (After April)
-
-1. Update environment variables on Render.com (or hosting platform):
+1. Update environment variables on Render.com:
 
    **Backend Service:**
    - Add/update: `ENABLE_MEAL_PREFERENCES=true`
@@ -157,126 +128,25 @@ VITE_ENABLE_MEAL_PREFERENCES=true
    **Frontend Service:**
    - Add/update: `VITE_ENABLE_MEAL_PREFERENCES=true`
 
-2. Redeploy both services (or Render auto-deploys on env var change)
+2. Redeploy both services
 
 3. Meal selection will immediately appear in RSVP form
 
 4. Send notification email to guests who already RSVP'd:
-   - "Menu options now available! Update your meal preferences"
+   - "The dinner menu is ready — update your entree selection."
    - Link to RSVP page
 
 ## Data Considerations
 
-### Existing RSVPs
+### Existing RSVPs (submitted before enabling)
 
-**Scenario:** Some guests RSVP'd while feature was disabled (no meal preferences)
-
-**Solution:**
-
-- These RSVPs remain valid with empty meal preferences
+- RSVPs remain valid with empty meal preferences
 - Admin dashboard can flag them as "Needs meal selection"
-- Follow-up email campaign to collect missing preferences
+- Follow-up email campaign can collect missing preferences
 - Guests can edit their RSVP to add meal selections
 
 ### New RSVPs After Enabling
 
-- All new RSVPs require meal preferences
+- All new RSVPs require one entree selection
 - Standard validation applies
 - No data migration needed
-
-## Admin Dashboard Notes
-
-The meal preferences feature flag also affects:
-
-1. **Statistics Display:**
-   - When disabled: Could show "Menu to be announced"
-   - When enabled: Shows full meal preference breakdown
-
-2. **Guest Management:**
-   - Existing meal data always visible (if present)
-   - Editing RSVPs respects current feature flag state
-
-3. **Data Export:**
-   - CSV exports include meal preferences regardless of flag
-   - Allows admin to see who needs follow-up
-
-## Troubleshooting
-
-### "Feature not toggling after env var change"
-
-**Problem:** Changed env var but feature still shows old state
-
-**Solutions:**
-
-- Backend: Restart server process
-- Frontend: Clear browser cache + rebuild
-- Render: Trigger manual redeploy after env var change
-
-### "Tests failing after enabling feature"
-
-**Problem:** Some tests fail when `ENABLE_MEAL_PREFERENCES=true`
-
-**Solution:**
-
-- Tests are designed to handle both states
-- Check that test environment is using correct env var
-- Run: `ENABLE_MEAL_PREFERENCES=true npm run test:rsvp:server`
-
-### "Guests see meal options but can't select"
-
-**Problem:** Frontend shows dropdowns but backend rejects
-
-**Cause:** Frontend and backend feature flags out of sync
-
-**Solution:**
-
-- Both must be enabled together
-- Check both services have matching env vars
-
-## Future Enhancements
-
-### Notification System
-
-When enabling feature in April:
-
-1. **Email Campaign:**
-   - Query users: `db.users.find({ hasRSVPed: true })`
-   - Filter RSVPs missing meal preferences
-   - Send "Menu now available" email with RSVP link
-
-2. **In-App Banner:**
-   - Show notification on next login
-   - "New: Select your meal preferences!"
-
-### Admin Controls
-
-Consider adding admin dashboard toggle:
-
-- Real-time feature enable/disable
-- No deployment required
-- Stored in database settings collection
-
-### Analytics
-
-Track meal selection adoption:
-
-- How many guests update preferences post-enable
-- Most popular meal choices
-- Timeline of selections
-
-## Summary
-
-✅ Feature successfully implemented  
-✅ Both enabled and disabled states tested  
-✅ Default state is DISABLED until April  
-✅ Zero data migration required  
-✅ Simple environment variable toggle  
-✅ Guest experience clearly communicated
-
-**Next Steps:**
-
-1. Deploy with feature disabled (current state)
-2. Collect RSVPs without meal preferences
-3. In April, flip env vars to `true`
-4. Send notification to existing guests
-5. Collect meal preferences for final headcount

--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2861,9 +2861,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4184,9 +4184,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4687,16 +4687,16 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/debug": {
@@ -4897,9 +4897,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -4927,9 +4927,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/server/src/models/RSVP.ts
+++ b/server/src/models/RSVP.ts
@@ -45,7 +45,7 @@
  * // const rsvp = new RSVP({
  * //   userId: '507f1f77bcf86cd799439011',
  * //   attending: 'YES',
- * //   guests: [{ fullName: 'John Doe', mealPreference: 'chicken' }]
+ * //   guests: [{ fullName: 'John Doe', mealPreference: 'brisket' }]
  * // });
  *
  * @example
@@ -65,7 +65,7 @@ import mongoose, { Schema, Document } from "mongoose";
  *
  * @interface IGuest
  * @property {string} fullName - Guest's full name (required for attending guests)
- * @property {string} mealPreference - Meal choice (chicken, beef, fish, vegetarian, vegan, other)
+ * @property {string} mealPreference - Meal choice (brisket, tritip, kids_chicken, kids_mac, dietary)
  * @property {string} [allergies] - Optional dietary restrictions or allergies (max 200 characters)
  */
 export interface IGuest {
@@ -122,13 +122,11 @@ const guestSchema = new Schema<IGuest>(
       trim: true,
       enum: {
         values: [
-          "chicken",
-          "beef",
-          "fish",
-          "vegetarian",
-          "vegan",
-          "kids",
-          "other",
+          "brisket",
+          "tritip",
+          "kids_chicken",
+          "kids_mac",
+          "dietary",
           "",
         ],
         message: "Invalid meal preference",
@@ -197,13 +195,11 @@ const rsvpSchema = new Schema<IRSVP>(
       trim: true,
       enum: {
         values: [
-          "chicken",
-          "beef",
-          "fish",
-          "vegetarian",
-          "vegan",
-          "kids",
-          "other",
+          "brisket",
+          "tritip",
+          "kids_chicken",
+          "kids_mac",
+          "dietary",
           "",
         ],
         message: "Invalid meal preference",

--- a/server/src/scripts/cleanupLegacyMealPreferences.ts
+++ b/server/src/scripts/cleanupLegacyMealPreferences.ts
@@ -6,14 +6,16 @@
  * will re-select from the current menu when the feature flag is enabled.
  *
  * Usage:
- *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2_dev
- *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2  (prod — requires confirmation)
+ *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2_dev --yes
+ *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2 --yes  (prod — review audit output first)
  */
 
 import { RSVP } from "../models/RSVP";
 import { BaseScript, ScriptUtils } from "../utils/script-runner";
 
 const VALID_MEAL_VALUES = ["brisket", "tritip", "kids_chicken", "kids_mac", "dietary", ""];
+// Display label for null/undefined — not legacy, just unset
+const NON_LEGACY_DISPLAY_KEYS = new Set([...VALID_MEAL_VALUES, "(none)"]);
 
 class CleanupLegacyMealPreferencesScript extends BaseScript {
   constructor() {
@@ -24,7 +26,7 @@ class CleanupLegacyMealPreferencesScript extends BaseScript {
     // Audit: count legacy values before cleanup
     const beforeCounts = await this.auditMealValues();
     const legacyCount = Object.entries(beforeCounts)
-      .filter(([value]) => !VALID_MEAL_VALUES.includes(value))
+      .filter(([value]) => !NON_LEGACY_DISPLAY_KEYS.has(value))
       .reduce((sum, [, count]) => sum + count, 0);
 
     this.logProgress("Current meal preference distribution:", beforeCounts);
@@ -56,9 +58,10 @@ class CleanupLegacyMealPreferencesScript extends BaseScript {
     this.logProgress(`Top-level mealPreference reset: ${topLevelResult.modifiedCount} documents`);
 
     // Clean guests[].mealPreference (array format)
+    // Use $elemMatch so docs with mixed valid/legacy guest values are still matched
     const arrayResult = await (RSVP as any).updateMany(
       {
-        "guests.mealPreference": { $exists: true, $nin: VALID_MEAL_VALUES },
+        guests: { $elemMatch: { mealPreference: { $exists: true, $nin: VALID_MEAL_VALUES } } },
       },
       { $set: { "guests.$[elem].mealPreference": "" } },
       { arrayFilters: [{ "elem.mealPreference": { $nin: VALID_MEAL_VALUES } }] }
@@ -71,7 +74,7 @@ class CleanupLegacyMealPreferencesScript extends BaseScript {
     this.logProgress("Meal preference distribution after cleanup:", afterCounts);
 
     const remainingLegacy = Object.entries(afterCounts)
-      .filter(([value]) => !VALID_MEAL_VALUES.includes(value))
+      .filter(([value]) => !NON_LEGACY_DISPLAY_KEYS.has(value))
       .reduce((sum, [, count]) => sum + count, 0);
 
     if (remainingLegacy > 0) {
@@ -84,18 +87,9 @@ class CleanupLegacyMealPreferencesScript extends BaseScript {
   private async auditMealValues(): Promise<Record<string, number>> {
     const counts: Record<string, number> = {};
 
-    // Count top-level mealPreference values
-    const topLevel = await (RSVP as any).aggregate([
-      { $match: { mealPreference: { $exists: true } } },
-      { $group: { _id: "$mealPreference", count: { $sum: 1 } } },
-    ]).exec();
-
-    for (const row of topLevel) {
-      const key = row._id || "(empty)";
-      counts[key] = (counts[key] || 0) + row.count;
-    }
-
-    // Count guests[].mealPreference values
+    // Only audit guests[] array — the canonical source of truth.
+    // Top-level mealPreference is a legacy sync field that mirrors guests[0],
+    // so counting both would double-count every single-guest RSVP.
     const guestLevel = await (RSVP as any).aggregate([
       { $unwind: "$guests" },
       { $match: { "guests.mealPreference": { $exists: true } } },
@@ -103,7 +97,9 @@ class CleanupLegacyMealPreferencesScript extends BaseScript {
     ]).exec();
 
     for (const row of guestLevel) {
-      const key = row._id || "(empty)";
+      // Preserve "" as a key — it's a valid value (unselected).
+      // Only map null/undefined to a display label.
+      const key = row._id ?? "(none)";
       counts[key] = (counts[key] || 0) + row.count;
     }
 

--- a/server/src/scripts/cleanupLegacyMealPreferences.ts
+++ b/server/src/scripts/cleanupLegacyMealPreferences.ts
@@ -1,0 +1,133 @@
+/**
+ * One-time cleanup script to reset legacy meal preference values.
+ *
+ * Legacy values (chicken, beef, fish, vegetarian, vegan, kids, other)
+ * are no longer valid enum values. This script sets them to "" so guests
+ * will re-select from the current menu when the feature flag is enabled.
+ *
+ * Usage:
+ *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2_dev
+ *   npx tsx src/scripts/cleanupLegacyMealPreferences.ts --db djforever2  (prod — requires confirmation)
+ */
+
+import { RSVP } from "../models/RSVP";
+import { BaseScript, ScriptUtils } from "../utils/script-runner";
+
+const VALID_MEAL_VALUES = ["brisket", "tritip", "kids_chicken", "kids_mac", "dietary", ""];
+
+class CleanupLegacyMealPreferencesScript extends BaseScript {
+  constructor() {
+    super("CleanupLegacyMealPreferences");
+  }
+
+  async execute(): Promise<void> {
+    // Audit: count legacy values before cleanup
+    const beforeCounts = await this.auditMealValues();
+    const legacyCount = Object.entries(beforeCounts)
+      .filter(([value]) => !VALID_MEAL_VALUES.includes(value))
+      .reduce((sum, [, count]) => sum + count, 0);
+
+    this.logProgress("Current meal preference distribution:", beforeCounts);
+
+    if (legacyCount === 0) {
+      this.logProgress("No legacy meal preference values found. Nothing to clean up.");
+      return;
+    }
+
+    this.logProgress(`Found ${legacyCount} legacy meal preference values to reset.`);
+
+    const confirmed = await ScriptUtils.confirmOperation(
+      `This will reset ${legacyCount} meal preference values to empty string. Continue?`
+    );
+
+    if (!confirmed) {
+      this.logWarning("Cleanup cancelled by user.");
+      return;
+    }
+
+    // Clean top-level mealPreference (legacy single-guest format)
+    const topLevelResult = await (RSVP as any).updateMany(
+      {
+        mealPreference: { $exists: true, $nin: VALID_MEAL_VALUES },
+      },
+      { $set: { mealPreference: "" } }
+    ).exec();
+
+    this.logProgress(`Top-level mealPreference reset: ${topLevelResult.modifiedCount} documents`);
+
+    // Clean guests[].mealPreference (array format)
+    const arrayResult = await (RSVP as any).updateMany(
+      {
+        "guests.mealPreference": { $exists: true, $nin: VALID_MEAL_VALUES },
+      },
+      { $set: { "guests.$[elem].mealPreference": "" } },
+      { arrayFilters: [{ "elem.mealPreference": { $nin: VALID_MEAL_VALUES } }] }
+    ).exec();
+
+    this.logProgress(`Guest array mealPreference reset: ${arrayResult.modifiedCount} documents`);
+
+    // Audit: count values after cleanup
+    const afterCounts = await this.auditMealValues();
+    this.logProgress("Meal preference distribution after cleanup:", afterCounts);
+
+    const remainingLegacy = Object.entries(afterCounts)
+      .filter(([value]) => !VALID_MEAL_VALUES.includes(value))
+      .reduce((sum, [, count]) => sum + count, 0);
+
+    if (remainingLegacy > 0) {
+      this.logWarning(`${remainingLegacy} legacy values still remain — may need manual review.`);
+    } else {
+      this.logProgress("All legacy meal preference values have been cleared.");
+    }
+  }
+
+  private async auditMealValues(): Promise<Record<string, number>> {
+    const counts: Record<string, number> = {};
+
+    // Count top-level mealPreference values
+    const topLevel = await (RSVP as any).aggregate([
+      { $match: { mealPreference: { $exists: true } } },
+      { $group: { _id: "$mealPreference", count: { $sum: 1 } } },
+    ]).exec();
+
+    for (const row of topLevel) {
+      const key = row._id || "(empty)";
+      counts[key] = (counts[key] || 0) + row.count;
+    }
+
+    // Count guests[].mealPreference values
+    const guestLevel = await (RSVP as any).aggregate([
+      { $unwind: "$guests" },
+      { $match: { "guests.mealPreference": { $exists: true } } },
+      { $group: { _id: "$guests.mealPreference", count: { $sum: 1 } } },
+    ]).exec();
+
+    for (const row of guestLevel) {
+      const key = row._id || "(empty)";
+      counts[key] = (counts[key] || 0) + row.count;
+    }
+
+    return counts;
+  }
+}
+
+async function main() {
+  const args = ScriptUtils.parseArgs();
+  const script = new CleanupLegacyMealPreferencesScript();
+
+  try {
+    await script.run({
+      dbName: args.db as string,
+      quiet: args.quiet as boolean,
+    });
+  } catch (error) {
+    console.error("Script execution failed:", error);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export default CleanupLegacyMealPreferencesScript;

--- a/server/src/services/adminService.ts
+++ b/server/src/services/adminService.ts
@@ -60,6 +60,22 @@ import type {
   AdminUserUpdateInput,
 } from "../types/graphql.js";
 
+const MEAL_PREFERENCE_LABELS: Record<string, string> = {
+  brisket: "BBQ Beef Brisket",
+  tritip: "Carved Tri Tip",
+  kids_chicken: "Kids - Chicken Tenders",
+  kids_mac: "Kids - Macaroni and Cheese",
+  dietary: "Dietary Accommodation",
+};
+
+function formatMealPreferenceLabel(
+  preference: string | null | undefined,
+): string {
+  const normalized = (preference || "").trim().toLowerCase();
+  if (!normalized) return "Not specified";
+  return MEAL_PREFERENCE_LABELS[normalized] || preference || "Not specified";
+}
+
 /**
  * Get comprehensive wedding statistics for admin dashboard
  *
@@ -114,7 +130,7 @@ export async function getWeddingStats(): Promise<AdminStats> {
       if (rsvp.attending === "YES") {
         if (rsvp.guests && rsvp.guests.length > 0) {
           for (const guest of rsvp.guests) {
-            const preference = guest.mealPreference || "Not specified";
+            const preference = formatMealPreferenceLabel(guest.mealPreference);
             mealPreferenceCounts.set(
               preference,
               (mealPreferenceCounts.get(preference) || 0) + 1,
@@ -126,7 +142,7 @@ export async function getWeddingStats(): Promise<AdminStats> {
           }
         } else {
           // Legacy format
-          const preference = rsvp.mealPreference || "Not specified";
+          const preference = formatMealPreferenceLabel(rsvp.mealPreference);
           mealPreferenceCounts.set(
             preference,
             (mealPreferenceCounts.get(preference) || 0) + 1,
@@ -276,14 +292,16 @@ export async function exportGuestListCSV(): Promise<string> {
         guestCount = rsvp.guestCount?.toString() || "1";
 
         if (rsvp.guests && rsvp.guests.length > 0) {
-          mealPrefs = rsvp.guests.map((g: any) => g.mealPreference).join("; ");
+          mealPrefs = rsvp.guests
+            .map((g: any) => formatMealPreferenceLabel(g.mealPreference))
+            .join("; ");
           dietaryRestrictions =
             rsvp.guests
               .filter((g: any) => g.allergies)
               .map((g: any) => g.allergies)
               .join("; ") || "None";
         } else {
-          mealPrefs = rsvp.mealPreference || "Not specified";
+          mealPrefs = formatMealPreferenceLabel(rsvp.mealPreference);
           dietaryRestrictions = rsvp.allergies || "None";
         }
       }

--- a/server/src/utils/validation.ts
+++ b/server/src/utils/validation.ts
@@ -246,12 +246,11 @@ export function validateGuestCount(count: number): number {
  * - Normalizes case for consistent storage
  *
  * Available Menu Options:
- * - chicken: Standard chicken entrée
- * - beef: Standard beef entrée
- * - fish: Standard fish entrée
- * - vegetarian: Vegetarian option
- * - vegan: Vegan option
- * - kids: Children's meal option
+ * - brisket: BBQ Beef Brisket (adult entree)
+ * - tritip: Carved Tri Tip (adult entree)
+ * - kids_chicken: Kids - Chicken Tenders (ages 3-12)
+ * - kids_mac: Kids - Macaroni and Cheese (ages 3-12)
+ * - dietary: Dietary Accommodation (guest describes needs in allergies field)
  *
  * @param preference - Raw meal preference from user
  * @param attending - Attendance status for conditional validation
@@ -261,12 +260,12 @@ export function validateGuestCount(count: number): number {
  * @example
  * ```typescript
  * // Attending guests (preference required)
- * const meal = validateMealPreference('CHICKEN', 'YES');
- * console.log(meal); // 'chicken'
+ * const meal = validateMealPreference('BRISKET', 'YES');
+ * console.log(meal); // 'brisket'
  *
  * // Non-attending guests (preference optional)
  * validateMealPreference('', 'NO'); // Returns ''
- * validateMealPreference('vegetarian', 'MAYBE'); // 'vegetarian'
+ * validateMealPreference('tritip', 'MAYBE'); // 'tritip'
  *
  * // Validation errors
  * validateMealPreference('', 'YES'); // ValidationError: Meal preference is required
@@ -285,12 +284,11 @@ export function validateMealPreference(
   mealPreferencesEnabled: boolean = true,
 ): string {
   const validPreferences = [
-    "chicken",
-    "beef",
-    "fish",
-    "vegetarian",
-    "vegan",
-    "kids",
+    "brisket",
+    "tritip",
+    "kids_chicken",
+    "kids_mac",
+    "dietary",
   ];
 
   const lowerPreference = preference.toLowerCase().trim();

--- a/server/tests/rsvp.e2e.test.ts
+++ b/server/tests/rsvp.e2e.test.ts
@@ -93,7 +93,7 @@ describe("RSVP End-to-End", () => {
             mutation {
               submitRSVP(
                 attending: YES
-                mealPreference: "chicken"
+                mealPreference: "brisket"
                 allergies: "None"
                 additionalNotes: "Excited!"
               ) {
@@ -114,7 +114,7 @@ describe("RSVP End-to-End", () => {
 
       expect(rsvpRes.body.data.submitRSVP).not.toBeNull();
       expect(rsvpRes.body.data.submitRSVP.attending).toBe("YES");
-      expect(rsvpRes.body.data.submitRSVP.mealPreference).toBe("chicken");
+      expect(rsvpRes.body.data.submitRSVP.mealPreference).toBe("brisket");
       expect(rsvpRes.body.data.submitRSVP.allergies).toBe("None");
       expect(rsvpRes.body.data.submitRSVP.additionalNotes).toBe("Excited!");
     });
@@ -134,13 +134,13 @@ describe("RSVP End-to-End", () => {
                 guests: [
                   {
                     fullName: "Test User"
-                    mealPreference: "chicken"
+                    mealPreference: "brisket"
                     allergies: "None"
                   }
                 ]
                 additionalNotes: "Looking forward to it!"
                 fullName: "Test User"
-                mealPreference: "chicken"
+                mealPreference: "brisket"
                 allergies: "None"
               }) {
                 _id
@@ -170,7 +170,7 @@ describe("RSVP End-to-End", () => {
       expect(rsvpRes.body.data.createRSVP.guests).toHaveLength(1);
       expect(rsvpRes.body.data.createRSVP.guests[0].fullName).toBe("Test User");
       expect(rsvpRes.body.data.createRSVP.guests[0].mealPreference).toBe(
-        "chicken",
+        "brisket",
       );
     });
 
@@ -282,13 +282,13 @@ describe("RSVP End-to-End", () => {
                 guests: [
                   {
                     fullName: ""
-                    mealPreference: "chicken"
+                    mealPreference: "brisket"
                     allergies: ""
                   }
                 ]
                 additionalNotes: ""
                 fullName: ""
-                mealPreference: "chicken"
+                mealPreference: "brisket"
                 allergies: ""
               }) {
                 _id
@@ -363,13 +363,13 @@ describe("RSVP End-to-End", () => {
                 guests: [
                   {
                     fullName: "Test User"
-                    mealPreference: "chicken"
+                    mealPreference: "brisket"
                     allergies: "None"
                   }
                 ]
                 additionalNotes: "Looking forward to it!"
                 fullName: "Test User"
-                mealPreference: "chicken"
+                mealPreference: "brisket"
                 allergies: "None"
               }) {
                 _id

--- a/server/tests/utils/test-helpers.ts
+++ b/server/tests/utils/test-helpers.ts
@@ -42,7 +42,7 @@ export class TestDataFactory {
       guests: [
         {
           fullName: "Test Guest",
-          mealPreference: "chicken",
+          mealPreference: "brisket",
           allergies: "None",
         },
       ],
@@ -128,7 +128,7 @@ export class TestDatabaseHelpers {
         guests: [
           {
             fullName: `Guest ${i + 1}`,
-            mealPreference: ["chicken", "beef", "vegetarian"][i % 3],
+            mealPreference: ["brisket", "tritip", "dietary"][i % 3],
           },
         ],
       });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
 

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -5,9 +5,7 @@ export default defineConfig({
     setupFiles: ["./tests/vitest.setup.ts"],
     environment: "node",
     globals: true,
-    // Use threads pool with maxConcurrency: 1 for true sequential execution
-    // Forks pool doesn't guarantee sequential execution in this vitest version
-    pool: "threads",
+    // In this Vitest version, enforce single-thread execution via thread limits.
     maxConcurrency: 1, // Run one test at a time across all files
     minThreads: 1,
     maxThreads: 1,


### PR DESCRIPTION
## Summary
- Replace placeholder meal options with the actual wedding menu: BBQ Beef Brisket, Carved Tri Tip, kids meals (Chicken Tenders, Mac & Cheese), and dietary accommodation
- Add per-entree descriptions, grouped dropdown with optgroups, and kids-specific sides copy
- Fix desktop text clipping in `<select>` dropdowns and align checkmark positioning
- Add legacy meal preference cleanup script for production data migration
- Fix pre-existing feature flag test failure and clean up tsconfig/vitest configs

## Deployment checklist
- [ ] Set `ENABLE_MEAL_PREFERENCES=true` on Render backend service
- [ ] Set `VITE_ENABLE_MEAL_PREFERENCES=true` on Render frontend static site (triggers rebuild)
- [ ] Run `cleanupLegacyMealPreferences.ts --db djforever2` against production DB
- [ ] Verify meal selection renders on production after deploy

## Test plan
- [x] Client tests pass (70/70)
- [x] Server tests pass (54/54)
- [x] Desktop and mobile visual verification — no text clipping
- [x] Kids meal selection shows kids-only sides
- [x] Dietary accommodation hint appears on selection
- [ ] Smoke test on production after env vars are set